### PR TITLE
fix issue occurred when inheriting parent attributes

### DIFF
--- a/connector.py
+++ b/connector.py
@@ -109,6 +109,7 @@ class Connection(Database):
         These objects are small stateless factories for cursors, which do all the real work.
     """
     def __init__(self, db_name, db_url='http://localhost:8123/', username=None, password=None):
+        super(Connection, self).__init__(db_name, db_url, username, password)
         self.db_name = db_name
         self.db_url = db_url
         self.username = username


### PR DESCRIPTION
I have met this issue: "AttributeError: 'Connection' object has no attribute 'readonly'" when query tables names. So I have analyzed your source. Based on my analysis of it, I have found one issue.
'Connection' class is inherited from Database but it does not inherit parent's method or attributes from Database class.
To fix it, I have added a following code.
```sh
super(Connection, self).__init__(db_name, db_url, username, password)
```
After that, it works for me well.