### PR TITLE
#3: Fix query result order reversed issue

### DIFF
--- a/connector.py
+++ b/connector.py
@@ -224,7 +224,7 @@ class Cursor(object):
             return None
         else:
             self._rownumber += 1
-            return self._data.pop()
+            return self._data.pop(0)
 
     def fetchmany(self, size=None):
         """Fetch the next set of rows of a query result, returning a sequence of sequences (e.g. a


### PR DESCRIPTION
Fix to issue #3. The query result was appended to a list one by one but was removed from the list in a FILO manner due to the pop() call. Passing 0 to pop() fixes the issue.