### PR TITLE
fix NPE

### DIFF
--- a/base.py
+++ b/base.py
@@ -227,7 +227,7 @@ class ClickHouseDialect(default.DefaultDialect):
             try:
                 coltype = ischema_names[col_type]
             except KeyError:
-                coltype = types.NullType
+                coltype = sqltypes.NullType
             result.append({
                 'name': col_name,
                 'type': coltype,


### PR DESCRIPTION
```
File “/var/www/superset/local/lib/python2.7/site-packages/sqlalchemy_clickhouse/base.py”, line 230, in get_columns
NameError: global name ‘types’ is not defined
```