### PR TITLE
Fix the db_type issue

### DIFF
--- a/connector.py
+++ b/connector.py
@@ -340,8 +340,8 @@ class Cursor(object):
         data = []
         for r in response:
             if not cols:
-                cols = [(f[0], f[1].db_type) for f in r._fields]
-            data.append([getattr(r, f[0]) for f in r._fields])
+                cols = [(f, r._fields[f].db_type) for f in r._fields]
+            data.append([getattr(r, f) for f in r._fields])
         self._data = data
         self._columns = cols
         self._state = self._STATE_FINISHED

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     download_url = 'https://github.com/cloudflare/sqlalchemy-clickhouse/releases/tag/v0.1',
     install_requires = [
         'sqlalchemy>=1.0.0',
-        'infi.clickhouse_orm>=0.8.0'
+        'infi.clickhouse_orm>=1.0.0'
     ],
     packages=[
         'sqlalchemy_clickhouse',


### PR DESCRIPTION
In infi.clickhouse_orm v1.0.0 the structure of infi.clickhouse_orm.models.AdHocModel has changed making current version of sqlalchemy-clickhouse incompatible.
The purpose of this pull request is to up infi.clickhouse_orm version and fix a compatibility issue: https://github.com/cloudflare/sqlalchemy-clickhouse/issues/22.
It was tested with newest clickhouse installation.