### PR TITLE
Adds support for passing arguments to the count function

### DIFF
--- a/base.py
+++ b/base.py
@@ -59,7 +59,7 @@ class ClickHouseIdentifierPreparer(PGIdentifierPreparer):
 
 class ClickHouseCompiler(PGCompiler):
     def visit_count_func(self, fn, **kw):
-        return 'count()'
+        return 'count{0}'.format(self.process(fn.clause_expr, **kw))
 
     def visit_random_func(self, fn, **kw):
         return 'rand()'


### PR DESCRIPTION
While using Apache Superset with Clickhouse, I discovered that the COUNT DISTINCT aggregate function was not working properly. The generated query would always just call `count()` with no arguments, resulting in a count of all values, rather than unique values.

After some digging, I found that this problem appears to have been fixed in an alternative implementation of a Clickhouse dialect for SQLAlchemy, namely in [this commit](https://github.com/xzkostyan/clickhouse-sqlalchemy/commit/899d850a778648e6ffd25e27f789c1aea93768ed), with corresponding unit test modifications in [this commit](https://github.com/xzkostyan/clickhouse-sqlalchemy/commit/8508a559c38743fc7e7d0c5221222b05c90cf038).

This pull request simply ports that fix over to sqlalchemy-clickhouse.