### PR TITLE
Add support for GROUP BY summaries and fix broken LIMIT m, n clause

### DIFF
--- a/base.py
+++ b/base.py
@@ -137,7 +137,7 @@ class ClickHouseCompiler(PGCompiler):
             functions.with_rollup: 'WITH ROLLUP',
             functions.with_totals: 'WITH TOTALS'
         })
-        summaries = [c for c in select._group_by_clause if c.name in summ_names]
+        summaries = [c for c in select._group_by_clause if getattr(c, 'name', None) and c.name in summ_names]
         # Use Counter instead of set to preserve order of group by cols
         select._group_by_clause = ClauseList(
           *list(Counter(select._group_by_clause) - Counter(summaries))

--- a/functions.py
+++ b/functions.py
@@ -1,0 +1,34 @@
+from sqlalchemy.sql.functions import GenericFunction
+
+class with_cube(GenericFunction):
+    r"""Implement the ``WITH CUBE`` grouping operation.
+
+    This function is used as part of the GROUP BY of a statement,
+    e.g. :meth:`.Select.group_by`::
+
+        stmt = select(
+            [func.sum(table.c.value), table.c.col_1, table.c.col_2]
+        ).group_by(table.c.col_1, table.c.col_2, func.with_cube())
+    """
+
+class with_rollup(GenericFunction):
+    r"""Implement the ``WITH ROLLUP`` grouping operation.
+
+    This function is used as part of the GROUP BY of a statement,
+    e.g. :meth:`.Select.group_by`::
+
+        stmt = select(
+            [func.sum(table.c.value), table.c.col_1, table.c.col_2]
+        ).group_by(table.c.col_1, table.c.col_2, func.with_rollup())
+    """
+
+class with_totals(GenericFunction):
+    r"""Implement the ``WITH TOTALS`` grouping operation.
+
+    This function is used as part of the GROUP BY of a statement,
+    e.g. :meth:`.Select.group_by`::
+
+        stmt = select(
+            [func.sum(table.c.value), table.c.col_1, table.c.col_2]
+        ).group_by(table.c.col_1, table.c.col_2, func.with_totals())
+    """

--- a/test/test_compiler.py
+++ b/test/test_compiler.py
@@ -1,0 +1,65 @@
+from sqlalchemy import column, func, Integer, select, String, table
+from test.testcase import BaseTestCase
+
+tbl = table(
+    'nba',
+    column('id', Integer),
+    column('name', String),
+    column('city', String),
+    column('wins', Integer)
+)
+
+class GroupBySummariesTestCase(BaseTestCase):
+    def test_group_by_without_summary(self):
+        stmt = select([tbl.c.id, tbl.c.name, tbl.c.city]).group_by(
+                  tbl.c.id, tbl.c.name, tbl.c.city)
+        self.assertEqual(
+            self.compile(stmt),
+            'SELECT id, name, city FROM nba GROUP BY id, name, city'
+        )
+
+    def test_group_by_with_rollup(self):
+        stmt = select([tbl.c.id]).group_by(tbl.c.id, func.with_rollup())
+        self.assertEqual(
+            self.compile(stmt),
+            'SELECT id FROM nba GROUP BY id WITH ROLLUP'
+        )
+
+    def test_group_by_with_rollup_with_totals(self):
+        stmt = select([tbl.c.id]).group_by(
+          tbl.c.id, func.with_rollup(), func.with_totals()
+        )
+        self.assertEqual(
+            self.compile(stmt),
+            'SELECT id FROM nba GROUP BY id WITH ROLLUP WITH TOTALS'
+        )
+
+    def test_group_by_rollup(self):
+        stmt = select([tbl.c.id]).group_by(
+          func.rollup(tbl.c.id, tbl.c.name)
+        )
+        self.assertEqual(
+            self.compile(stmt),
+            'SELECT id FROM nba GROUP BY ROLLUP(id, name)'
+        )
+
+    def test_group_by_cube(self):
+      stmt = select([tbl.c.id, tbl.c.name, tbl.c.city]).group_by(
+        func.cube(tbl.c.id, tbl.c.name, tbl.c.city)
+      )
+      self.assertEqual(
+          self.compile(stmt),
+          'SELECT id, name, city FROM nba GROUP BY CUBE(id, name, city)'
+      )
+
+    def test_group_by_with_cube_with_totals(self):
+      stmt = select(
+        [tbl.c.id, tbl.c.name, tbl.c.city, func.SUM(tbl.c.wins).label('wins')]
+      ).group_by(
+        tbl.c.id, tbl.c.name, tbl.c.city, func.with_cube(), func.with_totals()
+      )
+      self.assertEqual(
+          self.compile(stmt),
+          'SELECT id, name, city, SUM(wins) AS wins FROM nba GROUP BY id, name,'
+          ' city WITH CUBE WITH TOTALS'
+      )

--- a/test/test_compiler.py
+++ b/test/test_compiler.py
@@ -20,6 +20,14 @@ class GroupBySummariesTestCase(BaseTestCase):
             'SELECT id, name, city FROM nba GROUP BY id, name, city'
         )
 
+    def test_group_by_without_summary_with_labels(self):
+        stmt = select([tbl.c.name.label('labeled_name'), tbl.c.city.label('labeled_city')]).group_by(
+                  'labeled_name', 'labeled_city')
+        self.assertEqual(
+            self.compile(stmt),
+            'SELECT name AS labeled_name, city AS labeled_city FROM nba GROUP BY labeled_name, labeled_city'
+        )
+
     def test_group_by_with_rollup(self):
         stmt = select([tbl.c.id]).group_by(tbl.c.id, func.with_rollup())
         self.assertEqual(

--- a/test/testcase.py
+++ b/test/testcase.py
@@ -1,0 +1,22 @@
+# Attribution: https://github.com/xzkostyan/clickhouse-sqlalchemy
+import re
+from unittest import TestCase
+
+from sqlalchemy.orm import Query
+from base import dialect
+
+class BaseTestCase(TestCase):
+    strip_spaces = re.compile(r'[\n\t]')
+
+    def _compile(self, clause, **kw):
+        if isinstance(clause, Query):
+            context = clause._compile_context()
+            context.statement.use_labels = True
+            clause = context.statement
+
+        return clause.compile(dialect=dialect(), **kw)
+
+    def compile(self, clause, **kwargs):
+        return self.strip_spaces.sub(
+            '', str(self._compile(clause, **kwargs))
+        )

--- a/test/testcase.py
+++ b/test/testcase.py
@@ -8,11 +8,16 @@ from base import dialect
 class BaseTestCase(TestCase):
     strip_spaces = re.compile(r'[\n\t]')
 
-    def _compile(self, clause, **kw):
+    def _compile(self, clause, literal_binds=False):
         if isinstance(clause, Query):
             context = clause._compile_context()
             context.statement.use_labels = True
             clause = context.statement
+
+        kw = {}
+        if literal_binds:
+            kw['compile_kwargs'] = {}
+            kw['compile_kwargs']['literal_binds'] = True
 
         return clause.compile(dialect=dialect(), **kw)
 


### PR DESCRIPTION
Also added test cases.  GROUP BY summaries support (CUBE, ROLLUP, WITH CUBE, WITH ROLLUP, WITH TOTALS) requires sqlalchemy 1.2.13+