### PR TITLE
SSL Support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,7 @@ The DSN format is similar to that of regular Postgres::
     >>> sa.create_engine('clickhouse://username:password@hostname:port/database')
     Engine('clickhouse://username:password@hostname:port/database')
     
-For SSL ass ssl parameter to URL::
+For SSL add ssl parameter to URL::
 
     >>> import sqlalchemy as sa
     >>> sa.create_engine('clickhouse://username:password@hostname:port/database?ssl=True')

--- a/README.rst
+++ b/README.rst
@@ -18,6 +18,12 @@ The DSN format is similar to that of regular Postgres::
     >>> import sqlalchemy as sa
     >>> sa.create_engine('clickhouse://username:password@hostname:port/database')
     Engine('clickhouse://username:password@hostname:port/database')
+    
+For SSL ass ssl parameter to URL::
+
+    >>> import sqlalchemy as sa
+    >>> sa.create_engine('clickhouse://username:password@hostname:port/database?ssl=True')
+    Engine('clickhouse://username:password@hostname:port/database')
 
 It implements a dialect, so there's no user-facing API.
 

--- a/connector.py
+++ b/connector.py
@@ -122,7 +122,13 @@ class Connection(Database):
     """
         These objects are small stateless factories for cursors, which do all the real work.
     """
-    def __init__(self, db_name, db_url='http://localhost:8123/', username=None, password=None, readonly=False):
+    def __init__(self, db_name, db_url='http://localhost:8123/', username=None, password=None, readonly=False, ssl="False"):
+        if ssl.upper() == "TRUE":
+            db_url = db_url.replace("http", "https")
+        elif ssl.upper() == "FALSE":
+            pass
+        else:
+            raise ValueError("Not Supported value of ssl parameter, only True/False values are accepted")
         super(Connection, self).__init__(db_name, db_url, username, password, readonly)
         self.db_name = db_name
         self.db_url = db_url


### PR DESCRIPTION
Fix for SSL support, added ssl URL parameter to force using HTTPS instead HTTP for connection.

as mentioned in https://github.com/cloudflare/sqlalchemy-clickhouse/issues/50