### PR TITLE
rely on session that includes auth when patching Database

### DIFF
--- a/connector.py
+++ b/connector.py
@@ -100,7 +100,7 @@ def _send(self, data, settings=None, stream=False):
     if PY3 and isinstance(data, string_types):
         data = data.encode('utf-8')
     params = self._build_params(settings)
-    r = requests.post(self.db_url, params=params, data=data, stream=stream)
+    r = self.request_session.post(self.db_url, params=params, data=data, stream=stream, timeout=self.timeout)
     if r.status_code != 200:
         raise Exception(r.text)
     return r

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     download_url = 'https://github.com/cloudflare/sqlalchemy-clickhouse/releases/tag/v0.1.5',
     install_requires = [
         'sqlalchemy>=1.0.0',
-        'infi.clickhouse_orm>=1.0.0'
+        'infi.clickhouse_orm>=1.2.0'
     ],
     packages=[
         'sqlalchemy_clickhouse',


### PR DESCRIPTION
Behavior changed in `infi.clickhouse_orm>==1.2.0` such that when `Database` is instantiated a request is make to check if the database exists. Without using `self.request_session` to make the post auth is not included in the request causing an exception. 