### PR TITLE
Add support for DateTime64

### DIFF
--- a/base.py
+++ b/base.py
@@ -47,6 +47,7 @@ ischema_names = {
     'Enum16': VARCHAR,
     'Array': ARRAY,
     'Decimal': DECIMAL,
+    "DateTime64": TIMESTAMP,
 }
 
 class ClickHouseIdentifierPreparer(PGIdentifierPreparer):


### PR DESCRIPTION
Recent versions of Clickhouse support a DateTime64 for timestamps with millisecond precision.