### PR TITLE
Add timeout parameter for connect_args

### DIFF
--- a/connector.py
+++ b/connector.py
@@ -125,14 +125,14 @@ class Connection(Database):
     """
         These objects are small stateless factories for cursors, which do all the real work.
     """
-    def __init__(self, db_name, db_url='http://localhost:8123/', username=None, password=None, readonly=False, ssl="False"):
+    def __init__(self, db_name, db_url='http://localhost:8123/', username=None, password=None, readonly=False, ssl="False", timeout=60):
         if ssl.upper() == "TRUE":
             db_url = db_url.replace("http", "https")
         elif ssl.upper() == "FALSE":
             pass
         else:
             raise ValueError("Not Supported value of ssl parameter, only True/False values are accepted")
-        super(Connection, self).__init__(db_name, db_url, username, password, readonly)
+        super(Connection, self).__init__(db_name, db_url, username, password, readonly, timeout=timeout)
         self.db_name = db_name
         self.db_url = db_url
         self.username = username


### PR DESCRIPTION
fix the error that can not set the **timeout** for the connect_args
```
>> engine = create_engine('clickhouse://default:@localhost:8123/default', connect_args=={"timeout":180})
TypeError: __init__() got an unexpected keyword argument 'timeout'
```