### PR TITLE
Add missing 'six' dependency

### DIFF
--- a/connector.py
+++ b/connector.py
@@ -8,7 +8,6 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 import re
 import uuid
-import requests
 from infi.clickhouse_orm.models import ModelBase
 from infi.clickhouse_orm.database import Database
 from datetime import datetime

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,8 @@ setup(
     download_url = 'https://github.com/cloudflare/sqlalchemy-clickhouse/releases/tag/v0.1.5',
     install_requires = [
         'sqlalchemy>=1.0.0',
-        'infi.clickhouse_orm>=1.2.0'
+        'infi.clickhouse_orm>=1.2.0',
+        'six>=1.16.0',
     ],
     packages=[
         'sqlalchemy_clickhouse',


### PR DESCRIPTION
`six` is directly imported in https://github.com/cloudflare/sqlalchemy-clickhouse/blob/master/connector.py#L106.

Without this, the `example.py` fails to run with:
```
$ python3 example.py
Traceback (most recent call last):
  File "/Users/honza/projects/sqlalchemy-clickhouse/example.py", line 4, in <module>
    import connector
  File "/Users/honza/projects/sqlalchemy-clickhouse/connector.py", line 105, in <module>
    from six import PY3, string_types
ModuleNotFoundError: No module named 'six'
```